### PR TITLE
Fix to enable demo from calendar installed in a sub-folder

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -5,7 +5,7 @@
 	var options = {
 		events_url: 'events.json.php',
 		view: 'month',
-		tmpl_path: '/tmpls/',
+		tmpl_path: 'tmpls/',
         day: '2013-03-12',
 		first_day: 2,
 		onAfterEventsLoad: function(events) {


### PR DESCRIPTION
This is a huge update (:wink:) that fixes the execution of the demo when calendar is not installed in the root directory
