### PR TITLE
Fix default holidays

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -116,8 +116,14 @@ if(!String.prototype.format) {
     };
 
     function Calendar(params, context) {
-
-        this.options = $.extend(true, {}, defaults, params);
+        
+        this.options = $.extend(true, {}, defaults);
+        if(params) {
+            if(params.holidays) {
+                delete this.options.holidays;
+            }
+            $.extend(true, this.options, params);
+        }
         this.context = context;
 
         context.css('width', this.options.width);


### PR DESCRIPTION
When `params` contains `holidays`, the current code merges the default holidays with the ones from `params`.
This is not correct, since users usually want to specify their holidays, they don't want to merge the ones they specify with the default ones (for instance because in their Country they don't have one of the default holidays).
