### PR TITLE
Move holidays from default to example

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -6,7 +6,12 @@
 		events_url: 'events.json.php',
 		view: 'month',
 		tmpl_path: 'tmpls/',
-        day: '2013-03-12',
+		day: '2013-03-12',
+		holidays: {
+			'08-03': 'International Women\'s Day',
+			'25-12': 'Christmas\'s',
+			'01-05': "International labor day"
+		},
 		first_day: 2,
 		onAfterEventsLoad: function(events) {
 			if(!events) {

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -70,11 +70,6 @@ if(!String.prototype.format) {
                 today: 'cal-day-today'
             }
         },
-        holidays: {
-            '08-03': 'International Women\'s Day',
-            '25-12': 'Christmas\'s',
-            '01-05': "International labor day"
-        },
         enable_easter_holidays: false, // Set to true if you want to enable Easter and Easter Monday as holidays
         views: {
             year: {


### PR DESCRIPTION
Since every country has its own holidays, we should remove the default holidays.
To let developers know about it, we can add these holidays to the example page.
Supersedes https://github.com/Serhioromano/bootstrap-calendar/pull/30
