### PR TITLE
fix incorrect computation of starting day

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -271,9 +271,6 @@ if(!String.prototype.format) {
                 if(self.options.first_day == 1) {
                     event.start_day = (event.start_day + 6) % 7;
                 }
-                if(self.options.start_day < 0) {
-                    event.start_day = 0;
-                }
                 if((event.end - event.start) <= 86400000) {
                     event.days = 1;
                 } else {


### PR DESCRIPTION
if first day of week was set to monday, events starting at sunday displayed incorrectly in week view
