### PR TITLE
Use standard country code

### DIFF
--- a/js/language/el-GR.js
+++ b/js/language/el-GR.js
@@ -1,7 +1,7 @@
 if(!window.calendar_languages) {
 	window.calendar_languages = {};
 }
-window.calendar_languages['el-EL'] = {
+window.calendar_languages['el-GR'] = {
 	error_noview: 'Ημερολόγιο: Η προβολή {0} δεν βρέθηκε',
 	error_dateformat: 'Ημερολόγιο: Η μορφή της ημερομηνίας {0} δεν είναι έγκυρη. Παρακαλώ χρησιμοποιήστε "now" ή "yyyy-mm-dd"',
 	error_loadurl: 'Ημερολόγιο: Η διεύθυνση λήψης των event δεν έχει καθοριστεί',


### PR DESCRIPTION
The correct country code for Greece is `GR` and not `EL`. See
http://www.iso.org/iso/home/standards/country_codes/country_names_and_code_elements.htm
