### PR TITLE
Fix eventlist in year view

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -805,7 +805,7 @@ if(!String.prototype.format) {
 
 		var that = $(that);
 		var cell = that.closest('.cal-cell');
-		var row = that.closest('.cal-row-fluid');
+		var row = (self.options.view === 'year') ? that.closest('.row-fluid') :  that.closest('.cal-row-fluid');
 		var tick_position = cell.data('cal-row');
 
 		that.fadeOut('fast');


### PR DESCRIPTION
In event view we have the parent row with the class 'row-fluid', for month view we have 'cal-row-fluid'.
