### PR TITLE
Hide overflowing header texts

### DIFF
--- a/css/calendar.css
+++ b/css/calendar.css
@@ -116,7 +116,9 @@
 }
 .cal-row-head [class*="cal-cell"]:first-child,
 .cal-row-head [class*="cal-cell"] {
-  min-height: auto;
+	min-height: auto;
+  	overflow: hidden;
+	text-overflow: ellipsis;
 }
 .cal-events-num {
   margin-top: 20px;

--- a/less/month.less
+++ b/less/month.less
@@ -1,6 +1,8 @@
 .cal-row-head [class*="cal-cell"]:first-child,
 .cal-row-head [class*="cal-cell"] {
-  min-height: auto;
+	min-height: auto;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 .cal-events-num {
   margin-top: 20px;


### PR DESCRIPTION
To solve the [problem](https://github.com/Serhioromano/bootstrap-calendar/issues/128) reported by @gdscei: let's avoid header texts out of cell bounds:

![narrow-view](https://f.cloud.github.com/assets/928116/1251874/8b7c7500-2b3b-11e3-9889-2ec714931a43.png)
