### PR TITLE
Let's allow rebuilding css from less with grunt

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -3,10 +3,29 @@ module.exports = function(grunt) {
 	// Project configuration.
 	grunt.initConfig({
 		pkg: grunt.file.readJSON('package.json'),
-		cssmin: {
-			compress: {
+		less: {
+			options: {
+				ieCompat: true,
+				strictImports: false,
+				syncImport: false,
+				report: 'min'
+			},
+			css: {
+				options: {
+					compress: false,
+					yuicompress: false
+				},
 				files: {
-					'css/calendar.min.css': ['css/calendar.css']
+					'css/calendar.css': 'less/calendar.less',
+				}
+			},
+			css_min: {
+				options: {
+					compress: true,
+					yuicompress: true
+				},
+				files: {
+					'css/calendar.min.css': 'css/calendar.css'
 				}
 			}
 		},
@@ -21,11 +40,11 @@ module.exports = function(grunt) {
 		}
 	});
 
-	// Load the plugin that provides the "uglify" task.
-	grunt.loadNpmTasks('grunt-contrib-cssmin');
+	// Load the plugin that provides the tasks.
+	grunt.loadNpmTasks('grunt-contrib-less');
 	grunt.loadNpmTasks('grunt-contrib-uglify');
 
 	// Default task(s).
-	grunt.registerTask('default', ['cssmin', 'uglify']);
+	grunt.registerTask('default', ['less:css', 'less:css_min', 'uglify']);
 
 };

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "gitHead": "fc46075a07e08b1796f959c6562d851acce00751",
   "devDependencies": {
     "grunt": "~0.4.1",
-    "grunt-contrib-cssmin": "~0.5.0",
+    "grunt-contrib-less": "~0.7.0",
     "grunt-contrib-uglify": "~0.2.0",
     "bower": "~0.8.5"
   }


### PR DESCRIPTION
Calling `grunt` now builds `calendar.css` from `calendar.less`, and after generates `calendar.min.css` from `calendar.css`
