### PR TITLE
Use utf-8 chars instead of html entities

### DIFF
--- a/js/language/es-ES.js
+++ b/js/language/es-ES.js
@@ -3,13 +3,13 @@ if(!window.calendar_languages) {
 }
 window.calendar_languages['es-ES'] = {
 	error_noview: 'Calendario: Vista {0} no encontrada',
-	error_dateformat: 'Calendario: Formato de fecha inv&aacute;lido {0}. Debe ser "now" o "yyyy-mm-dd"',
+	error_dateformat: 'Calendario: Formato de fecha inválido {0}. Debe ser "now" o "yyyy-mm-dd"',
 	error_loadurl: 'Calendario: URL de carga de eventos no configurada',
-	error_where: 'Calendario: Direcci&oacute;n de navegaci&oacute;n incorrecta {0}. Los valores correctos son "next" o "prev" o "today"',
+	error_where: 'Calendario: Dirección de navegación incorrecta {0}. Los valores correctos son "next" o "prev" o "today"',
 
 	no_events_in_day: 'No hay eventos hoy',
 
-	title_year: 'A&ntilde;o {0}',
+	title_year: 'Año {0}',
 	title_month: '{0} {1}',
 	title_week: 'Semana {0} del {1}',
 	title_day: '{0} {1} {2} {3}',
@@ -45,10 +45,10 @@ window.calendar_languages['es-ES'] = {
 	d0: 'Domingo',
 	d1: 'Lunes',
 	d2: 'Martes',
-	d3: 'Mi&eacute;rcoles',
+	d3: 'Miércoles',
 	d4: 'Jueves',
 	d5: 'Viernes',
-	d6: 'S&aacute;bado',
+	d6: 'Sábado',
 
 	easter: 'Pascuas',
 	easterMonday: 'Lunes de Pascuas',

--- a/js/language/es-MX.js
+++ b/js/language/es-MX.js
@@ -3,9 +3,9 @@ if(!window.calendar_languages) {
 }
 window.calendar_languages['es-MX'] = {
 	error_noview: 'Calendar: Vista {0} no encontrada',
-	error_dateformat: 'Calendar: Formato de Fecha Inv&aacute;lido {0}. Debe ser "now" o con el formato "yyyy-mm-dd"',
+	error_dateformat: 'Calendar: Formato de Fecha Inválido {0}. Debe ser "now" o con el formato "yyyy-mm-dd"',
 	error_loadurl: 'Calendar: URL de datos no definida',
-	error_where: 'Calendar: Direcci&oacute;nd de navegaci&oacute;n err&oacute;nea {0}. Valores v&aacute;lidos: "next" o "prev" o "today"',
+	error_where: 'Calendar: Direcciónd de navegación errónea {0}. Valores válidos: "next" o "prev" o "today"',
 
 	title_year: 'Año {0}',
 	title_month: '{0} año {1}',
@@ -43,10 +43,10 @@ window.calendar_languages['es-MX'] = {
 	d0: 'Domingo',
 	d1: 'Lunes',
 	d2: 'Martes',
-	d3: 'Mi&eacute;rcoles',
+	d3: 'Miércoles',
 	d4: 'Jueves',
 	d5: 'Viernes',
-	d6: 'S&aacute;bado',
+	d6: 'Sábado',
 
 	easter: 'Pascuas',
 	easterMonday: 'Lunes de Pascuas',


### PR DESCRIPTION
Let's use utf-8 characters instead of html entities.

To see the problem that this solves see http://bootstrap-calendar.azurewebsites.net/ in `Spanish (Spain)` language for the year view. There you can read `A&ntilde;o 2013` instead of `Año 2013`
