### PR TITLE
Make it possible to set options.tmpl_path to a function returning a path...

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -899,13 +899,22 @@ if(!String.prototype.formatNum) {
 		});
 	};
 
+  Calendar.prototype._templatePath = function(name) {
+    if (typeof this.options.tmpl_path == 'function') {
+      return this.options.tmpl_path(name)
+    }
+    else {
+      return this.options.tmpl_path + name + '.html';
+    }
+  };
+
 	Calendar.prototype._loadTemplate = function(name) {
 		if(this.options.templates[name]) {
 			return;
 		}
 		var self = this;
 		$.ajax({
-			url:      this.options.tmpl_path + name + '.html',
+			url:      self._templatePath(name),
 			dataType: 'html',
 			type:     'GET',
 			async:    false,
@@ -914,7 +923,6 @@ if(!String.prototype.formatNum) {
 				self.options.templates[name] = _.template(html);
 			});
 	};
-
 
 	Calendar.prototype._update = function() {
 		var self = this;


### PR DESCRIPTION
... based on the name of a template _or_ a string containing the root path to html templates. 

The change makes it possible to override the paths or generate them on the server-side if the deployment method requires that. 

An example is the sprockets asset pipeline used by Rails which adds a digest to an asset's filename based on the contents of each individual file.

It should also take care of: https://github.com/Serhioromano/bootstrap-calendar/pull/266

A trivial example usage that is an equivalent of setting `tmpl_path` to a string (which btw. is still supported):

```
var options = {
  tmpl_path: function(name) {
    return '/templates/' + name + '.html';
  },
}
```

Of course, creating a function like that makes most sense if the paths are generated on the server side. 

While the pull request has no dependencies on Rails, I needed it for my Rails application. An example in Rails would be using the following code:

```
var options = {
  tmpl_path: function(name) {
    var htmlAssets = <%= raw paths_to_html_templates.to_json %>;
    return htmlAssets[name];
  },
...
}
var calendar = $("#calendar").calendar(options);
...
```

Assuming the templates are under /app/assets/templates/, this is the code for the helper:

```
module ApplicationHelper
  ...

  def paths_to_html_templates
    Hash[Pathname.glob(File.join(Rails.root, "app", "assets", "templates", "*.html")).map { |p| [p.basename(".*"), path_to_asset(p.basename)] }]
  end

...
```
