### PR TITLE
Requirement change to reflect current package name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   "require": {
     "components/jquery": "~1",
     "components/underscore": "~1",
-    "twitter/bootstrap": ">2.0.0",
+    "twbs/bootstrap": ">2.0.0",
     "moment/moment": "~2"
   }
 }


### PR DESCRIPTION
The package "twitter/bootstrap" redirects now to "twbs/bootstrap".
