### PR TITLE
Add new configuration variable to allow JSONP as datatype for events source

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -58,6 +58,8 @@ if(!String.prototype.formatNum) {
 		//   returns an array of events (as described in events property description)
 		// - An array containing the events
 		events_source:      '',
+		// if events source is a URL you can change the data type to JSONP
+		source_data_type:   'json',
 		// Path to templates should end with slash /. It can be as relative
 		// /component/bootstrap-calendar/tmpls/
 		// or absolute
@@ -868,7 +870,7 @@ if(!String.prototype.formatNum) {
 						}
 						$.ajax({
 							url:      buildEventsUrl(source, params),
-							dataType: 'json',
+							dataType: self.options.source_data_type,
 							type:     'GET',
 							async:    false
 						}).done(function(json) {


### PR DESCRIPTION
In setting up bootstrap-calendar I realized that I needed to get my events JSON object via JSONP from a different domain.

Added new configuration variable "source_data_type" (default: 'json') that can be set to 'jsonp' for the jQuery AJAX call.
