### PR TITLE
Updating docs to reflect html markup for modal use with bootstrap 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,24 @@ and then set:
 
 This will enable the modal, and populate it with an iframe with the contents of event.url .
 
+For Bootstrap v3, use
+
+    <div class="modal fade" id="events-modal">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                    <h3>Event</h3>
+                </div>
+                <div class="modal-body" style="height: 400px">
+                </div>
+                <div class="modal-footer">
+                    <a href="#" data-dismiss="modal" class="btn">Close</a>
+                </div>
+            </div>
+        </div>
+    </div>
+
 ### Modal content source
 
 There are three options for populating the contents of the modal, controlled by the `modal_type` option:


### PR DESCRIPTION
I used to markup in the docs for opening events in modal dialogs, and it didn't work. I wasn't sure if this was documented elsewhere, but I added the markup used by the bootstrap v3 demo to the docs.
