### PR TITLE
fix warning messages in browser console for week view

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -452,7 +452,7 @@ if(!String.prototype.formatNum) {
 		var start = new Date(this.options.position.start.getTime());
 		start.setHours(time_start[0]);
 		start.setMinutes(time_start[1]);
-		var end = new Date(this.options.position.start.getTime());
+		var end = new Date(this.options.position.end.getTime());
 		end.setHours(time_end[0]);
 		end.setMinutes(time_end[1]);
 


### PR DESCRIPTION
Simple fix to get rid of warning messages for events with end times for any day other than the first day of the week in the week view.
