### PR TITLE
LESS folder should be included when installing via bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,8 +8,7 @@
   "ignore": [
     "**/.*",
     "node_modules",
-    "components",
-    "less"
+    "components"
   ],
   "dependencies": {
     "jquery": "~1.10.2",


### PR DESCRIPTION
The README for this project mentions you can easily change the look using a .less file, but when you install it via bower, no 'less' folder is included. There would be a lot of utility to being able to install the package via bower, then use / include the less file within another. 

Thanks!
