### PR TITLE
correct the modal_title tag

### DIFF
--- a/index-bs3.html
+++ b/index-bs3.html
@@ -104,7 +104,7 @@
 			<div class="modal-content">
 				<div class="modal-header">
 					<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-					<h4 class="modal-title">Event</h4>
+					<h3 class="modal-title">Event</h3>
 				</div>
 				<div class="modal-body" style="height: 400px">
 				</div>


### PR DESCRIPTION
I look at the calendar.js and find that when you set modal_title function in option, only `<h3>` will be used to
show the title. So if you keep the tag `<h4>`, the modal_title function will never work.

Besides, instead of finding the `<h3>` tag in modal, I think it's better to find the tag who's class is `'modal-title'`. But I don't know whether the change of the behavior will break something, so I just change h4 to h3.
