### PR TITLE
Use separate ajax url for ajax modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ For Bootstrap v3, use
 
 There are three options for populating the contents of the modal, controlled by the `modal_type` option:
 - **iframe** (default) - populates modal with iframe, iframe.src set to event.url
-- **ajax** - gets html from event.url, this is useful when you just have a snippet of html and want to take advantage of styles in the calendar page
+- **ajax** - gets html from event.ajax_url (or events.url, if ajax_url is not set); this is useful when you just have a snippet of html and want to take advantage of styles in the calendar page.
 - **template** - will render a template (example in tmpls/modal.html) that gets the `event` and a reference to the `calendar` object.
 
 ### Modal title

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -984,6 +984,7 @@ if(!String.prototype.formatNum) {
 			event.stopPropagation();
 
 			var url = $(this).attr('href');
+			var ajax_url = $(this).attr('data-event-ajax-url') == undefined ? url : $(this).attr('data-event-ajax-url');
 			var id = $(this).data("event-id");
 			var event = _.find(self.options.events, function(event) {
 				return event.id == id
@@ -1007,7 +1008,7 @@ if(!String.prototype.formatNum) {
 								break;
 
 							case "ajax":
-								$.ajax({url: url, dataType: "html", async: false, success: function(data) {
+								$.ajax({url: ajax_url, dataType: "html", async: false, success: function(data) {
 									modal_body.html(data);
 								}});
 								break;

--- a/tmpls/day.html
+++ b/tmpls/day.html
@@ -10,7 +10,7 @@
 				<% _.each(all_day, function(event){ %>
 					<div class="day-highlight dh-<%= event['class'] %>">
 						<a href="<%= event.url ? event.url : 'javascript:void(0)' %>" data-event-id="<%= event.id %>"
-						   data-event-class="<%= event['class'] %>" class="event-item">
+						   data-event-class="<%= event['class'] %>"<%= event.ajax_url ? ' data-event-ajax-url="' + event.ajax_url + '"' : '' %> class="event-item">
 							<%= event.title %></a>
 					</div>
 				<% }); %>
@@ -25,7 +25,7 @@
 					<div class="day-highlight dh-<%= event['class'] %>">
 						<span class="cal-hours pull-right"><%= event.end_hour %></span>
 						<a href="<%= event.url ? event.url : 'javascript:void(0)' %>" data-event-id="<%= event.id %>"
-						   data-event-class="<%= event['class'] %>" class="event-item">
+						   data-event-class="<%= event['class'] %>"<%= event.ajax_url ? ' data-event-ajax-url="' + event.ajax_url + '"' : '' %> class="event-item">
 							<%= event.title %></a>
 					</div>
 				<% }); %>
@@ -50,7 +50,7 @@
 			<div class="pull-left day-event day-highlight dh-<%= event['class'] %>" style="margin-top: <%= (event.top * 30) %>px; height: <%= (event.lines * 30) %>px">
 				<span class="cal-hours"><%= event.start_hour %> - <%= event.end_hour %></span>
 				<a href="<%= event.url ? event.url : 'javascript:void(0)' %>" data-event-id="<%= event.id %>"
-				   data-event-class="<%= event['class'] %>" class="event-item">
+				   data-event-class="<%= event['class'] %>"<%= event.ajax_url ? ' data-event-ajax-url="' + event.ajax_url + '"' : '' %> class="event-item">
 					<%= event.title %></a>
 			</div>
 		<% }); %>
@@ -63,7 +63,7 @@
 			<div class="day-highlight dh-<%= event['class'] %>">
 				<span class="cal-hours"><%= event.start_hour %></span>
 				<a href="<%= event.url ? event.url : 'javascript:void(0)' %>" data-event-id="<%= event.id %>"
-				   data-event-class="<%= event['class'] %>" class="event-item">
+				   data-event-class="<%= event['class'] %>"<%= event.ajax_url ? ' data-event-ajax-url="' + event.ajax_url + '"' : '' %> class="event-item">
 					<%= event.title %></a>
 			</div>
 			<% }); %>

--- a/tmpls/events-list.html
+++ b/tmpls/events-list.html
@@ -5,7 +5,7 @@
 			<li>
 				<span class="pull-left event <%= event['class'] %>"></span>&nbsp;
 				<a href="<%= event.url ? event.url : 'javascript:void(0)' %>" data-event-id="<%= event.id %>"
-					data-event-class="<%= event['class'] %>" class="event-item">
+					data-event-class="<%= event['class'] %>"<%= event.ajax_url ? ' data-event-ajax-url="' + event.ajax_url + '"' : '' %> class="event-item">
 					<%= event.title %></a>
 			</li>
 		<% }) %>

--- a/tmpls/month-day.html
+++ b/tmpls/month-day.html
@@ -3,7 +3,7 @@
 	<% if (events.length > 0) { %>
 		<div class="events-list" data-cal-start="<%= start %>" data-cal-end="<%= end %>">
 			<% _.each(events, function(event) { %>
-				<a href="<%= event.url ? event.url : 'javascript:void(0)' %>" data-event-id="<%= event.id %>" data-event-class="<%= event['class'] %>"
+				<a href="<%= event.url ? event.url : 'javascript:void(0)' %>" data-event-id="<%= event.id %>" data-event-class="<%= event['class'] %>"<%= event.ajax_url ? ' data-event-ajax-url="' + event.ajax_url + '"' : '' %>
 					class="pull-left event <%= event['class'] %>" data-toggle="tooltip"
 					title="<%= event.title %>"></a>
 			<% }); %>

--- a/tmpls/week-days.html
+++ b/tmpls/week-days.html
@@ -1,7 +1,7 @@
 <% _.each(events, function(event){ %>
 <div class="cal-row-fluid">
 	<div class="cal-cell<%= event.days%> cal-offset<%= event.start_day %> day-highlight dh-<%= event['class'] %>" data-event-class="<%= event['class'] %>">
-		<a href="<%= event.url ? event.url : 'javascript:void(0)' %>" data-event-id="<%= event.id %>" class="cal-event-week event<%= event.id %>"><%= event.title %></a>
+		<a href="<%= event.url ? event.url : 'javascript:void(0)' %>" data-event-id="<%= event.id %>"<%= event.ajax_url ? ' data-event-ajax-url="' + event.ajax_url + '"' : '' %> class="cal-event-week event<%= event.id %>"><%= event.title %></a>
 	</div>
 </div>
 <% }); %>

--- a/tmpls/year-month.html
+++ b/tmpls/year-month.html
@@ -3,7 +3,7 @@
 	<small class="cal-events-num badge badge-important pull-left"><%= events.length %></small>
 	<div class="hide events-list" data-cal-start="<%= start %>" data-cal-end="<%= end %>">
 		<% _.each(events, function(event) { %>
-			<a href="<%= event.url ? event.url : 'javascript:void(0)' %>" data-event-id="<%= event.id %>" data-event-class="<%= event['class'] %>"
+			<a href="<%= event.url ? event.url : 'javascript:void(0)' %>" data-event-id="<%= event.id %>" data-event-class="<%= event['class'] %>"<%= event.ajax_url ? ' data-event-ajax-url="' + event.ajax_url + '"' : '' %>
 				class="pull-left event <%= event['class'] %> event<%= event.id %>" data-toggle="tooltip"
 				title="<%= event.title %>"></a>
 		<% }); %>


### PR DESCRIPTION
Adds a separate ajax_url parameter for events, used for ajax modal popups.

This is so that the href url can be set differently, so if the user opens the link in a new tab instead of in the popup, a different url containing more than a snippet can be provided.