### PR TITLE
Strictness of date selection needed

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -1125,7 +1125,7 @@ if(!String.prototype.formatNum) {
 				return true;
 			}
 			var event_end = this.end || this.start;
-			if((parseInt(this.start) < end) && (parseInt(event_end) >= start)) {
+			if((parseInt(this.start) < end) && (parseInt(event_end) > start)) {
 				events.push(this);
 			}
 		});


### PR DESCRIPTION
If my events ends up right at midnight, it is still counted as an event when I think it shouldn't.