### PR TITLE
Fix bug that time_split in day view doesn't work

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -531,7 +531,7 @@ if(!String.prototype.formatNum) {
 		var time_start = this.options.time_start.split(":");
 		var time_split = parseInt(this.options.time_split);
 		var h = "" + (parseInt(time_start[0]) + hour * Math.max(time_split / 60, 1));
-		var m = "" + (time_split * part + ((hour == 0) ? parseInt(time_start[1]) : 0));
+		var m = "" + time_split * part;
 
 		return h.formatNum(2) + ":" + m.formatNum(2);
 	};


### PR DESCRIPTION
Problem: When I looked at the day view, I saw something like this when I configured time_split 15 minutes:

08:00
08:00
08:00
08:00
09:00
09:00
09:00
09:00
...

To fix this issue I made the _hour method a bit more naive.