### PR TITLE
Allow using moment 2.10 and bootstrap 3.3.4 with bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,6 +14,6 @@
     "jquery": "~1.10.2",
     "bootstrap": "~2.3.1 || ~3.3.4",
     "underscore": "~1.4.4",
-    "moment": "~2.0.0"
+    "moment": "2.x"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
   ],
   "dependencies": {
     "jquery": "~1.10.2",
-    "bootstrap": "~2.3.1",
+    "bootstrap": "~2.3.1 || ~3.3.4",
     "underscore": "~1.4.4",
     "moment": "~2.0.0"
   }


### PR DESCRIPTION
The calendar works very well with moment 2.10 and bootstrap 3, so I updated the bower dependencies to avoit conflicts when other packages require bootstrap 3 or moment 2.10, as said in issue #239 