### PR TITLE
use css class ".modal-title" instead of "h3" tag

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -1021,7 +1021,7 @@ if(!String.prototype.formatNum) {
 
 						//	set the title of the bootstrap modal
 						if(_.isFunction(self.options.modal_title)) {
-							modal.find("h3").html(self.options.modal_title(event));
+							modal.find(".modal-title").html(self.options.modal_title(event));
 						}
 					})
 					.on('shown.bs.modal', function() {


### PR DESCRIPTION
Hi Serhioromano,

Thank you for your code. I think it's better to use css class than the h3 tag to find the title of modal.

Thanks again,