### PR TITLE
Add utc_offset parameter when fetching data

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -868,7 +868,10 @@ if(!String.prototype.formatNum) {
 				if(source.length) {
 					loader = function() {
 						var events = [];
-						var params = {from: self.options.position.start.getTime(), to: self.options.position.end.getTime()};
+                                                var d = new Date();
+                                                var utc_offset = d.getTimezoneOffset();
+                                                var params = {from: self.options.position.start.getTime(), to: self.options.position.end.getTime(), utc_offset: utc_offset};
+
 						if(browser_timezone.length) {
 							params.browser_timezone = browser_timezone;
 						}


### PR DESCRIPTION
Would a patch such as the attached be considered?

I often find that I would like to know the actual date that the user requested, but this is skewed with the conversion to unixtime. For example, if a day view is requested, then I like to be able to default to that day the next time the calendar is displayed.

I know that it's possible to get the timezone name with jstz, but that doesn't provide the offset. Plus, this patch works without any extra libraries.

Comments welcome - I can rework if required.

Thanks,

Andy