### PR TITLE
Add extra section to move special files for composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,5 +19,19 @@
     "components/underscore": "~1",
     "twbs/bootstrap": ">2.0.0",
     "moment/moment": "~2"
+  },
+  "extra" : {
+    "component" : {
+      "scripts" : [
+        "js/calendar.min.js"
+      ],
+      "styles" : [
+        "css/calendar.min.css"
+      ],
+      "files" : [
+        "js/language/*.js",
+        "tmpls/*.*"
+      ]
+    }
   }
 }


### PR DESCRIPTION
The commit provides the extra section in composer.json to move dist files to a proper location. Many of the popular JS libs available using composer are using the "components" directory to provide an asset location outside the vendor directory. This makes it easier to gain access to the dist files if an administrator don't want to allow usage the vendor directory.