### PR TITLE
getX functions for Year, Month and Day

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -875,6 +875,21 @@ if(!String.prototype.formatNum) {
 		}
 		return;
 	};
+	
+	Calendar.prototype.getYear = function() {
+		var p = this.options.position.start;
+		return p.getFullYear();
+	};
+
+	Calendar.prototype.getMonth = function() {
+		var p = this.options.position.start;
+		return this.locale['m' + p.getMonth()];
+	};
+
+	Calendar.prototype.getDay = function() {
+		var p = this.options.position.start;
+		return this.locale['d' + p.getDay()];
+	};
 
 	Calendar.prototype.isToday = function() {
 		var now = new Date().getTime();


### PR DESCRIPTION
I have added functions to expose the year, month and day of the current calendar view. This is helpful for labelling a form with the current month, for example, or labelling buttons to change the view.