### PR TITLE
fix trailing commas and a missing semicolon

### DIFF
--- a/js/language/da-DK.js
+++ b/js/language/da-DK.js
@@ -70,6 +70,6 @@ window.calendar_languages['da-DK'] = {
 	  'easter+49':'Pinsedag',
 	  'easter+50':'2. Pinsedag',
 	  '25-12':'Juledag',
-	  '26-12':'2. Juledag',
+	  '26-12':'2. Juledag'
 	}
 };

--- a/js/language/de-AT.js
+++ b/js/language/de-AT.js
@@ -75,6 +75,6 @@ window.calendar_languages['de-AT'] = {
 		'24-12':     'Heiliger Abend',
 		'25-12':     'Weihnachten',
 		'26-12':     'Stefanitag',
-		'31-12':     'Silvester',
+		'31-12':     'Silvester'
 	}
 };

--- a/js/language/de-DE.js
+++ b/js/language/de-DE.js
@@ -74,6 +74,6 @@ window.calendar_languages['de-DE'] = {
 		'03-10':     'Tag der Deutschen Einheit',
 		'01-11':     'Allerheiligen',
 		'25-12':     'Erster Weihnachtsfeiertag',
-		'26-12':     'Zweiter Weihnachtsfeiertag',
+		'26-12':     'Zweiter Weihnachtsfeiertag'
 	}
 };

--- a/js/language/hr-HR.js
+++ b/js/language/hr-HR.js
@@ -59,4 +59,4 @@ window.calendar_languages['hr-HR'] = {
 
         first_day: 1,
         week_numbers_iso_8601: true
-}
+};

--- a/js/language/hu-HU.js
+++ b/js/language/hu-HU.js
@@ -73,7 +73,7 @@ window.calendar_languages['hu-HU'] = {
 		'08-20':     'Államalapítás ünnepe',
 		'10-23':     '1956-os forradalom és szabadságharc',
 		'25-12':     'Karácsony',
-		'26-12':     'Karácsony',
+		'26-12':     'Karácsony'
 	}
 
 };

--- a/js/language/ms-MY.js
+++ b/js/language/ms-MY.js
@@ -68,6 +68,6 @@ window.calendar_languages['ms-MY'] = {
 
 		'01-01':     				'Sambutan Tahun Baru',
 		'01-05':     				'Hari Pekerja',
-		'31-08':     				'Hari Kemerdekaan Malaysia (Independence Day)',
+		'31-08':     				'Hari Kemerdekaan Malaysia (Independence Day)'
 	}
 };

--- a/js/language/ro-RO.js
+++ b/js/language/ro-RO.js
@@ -87,6 +87,6 @@ window.calendar_languages['ro-RO'] = {
 		'01-12':  	 "Ziua Naţională a României",
 		'25-12':  	 "Naşterea Domnului Nostru Iisus Hristos – Crăciunul",
 		'26-12':  	 "A doua zi de Crăciun; Soborul Maicii",
-		'27-12':  	 "Sfântul Întâiul Mucenic şi Arhidiacon Ştefan",
+		'27-12':  	 "Sfântul Întâiul Mucenic şi Arhidiacon Ştefan"
 	}
 };

--- a/js/language/zh-TW.js
+++ b/js/language/zh-TW.js
@@ -61,6 +61,6 @@ window.calendar_languages['zh-TW'] = {
 
 	holidays:  {
 		'01-01': '元旦',
-        '10-10': '國慶日',
+        '10-10': '國慶日'
 	}
 };


### PR DESCRIPTION
Stumbled upon a few trailing commas causing problems in older IE versions.