### PR TITLE
Changed package.json to work with npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,7 @@
   "name": "bootstrap-calendar",
   "version": "0.2.4",
   "description": "Bootstrap full view calendar",
-  "main": [
-    "./js/calendar.js"
-  ],
+  "main": "./js/calendar.js",
   "scripts": {
     "test": ""
   },


### PR DESCRIPTION
Installation with npm did not work due to the following error:
`Path must be a string. Received [ './js/calendar.js' ]`

This change enables installation via npm