### PR TITLE
Feature more options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 components/
 .DS_Store
+/.project

--- a/css/calendar.css
+++ b/css/calendar.css
@@ -274,7 +274,7 @@
   margin-left: -60px;
 }
 .cal-day-box .day-event {
-  position: relative;
+  position: absolute;
   overflow: hidden;
 }
 .cal-day-box .day-event.max-width {

--- a/css/calendar.css
+++ b/css/calendar.css
@@ -128,7 +128,7 @@
   display: block;
   width: 100%;
 }
-#cal-week-box {
+.cal-week-box {
   position: absolute;
   width: 70px;
   left: -71px;
@@ -136,7 +136,7 @@
   padding: 8px 5px;
   cursor: pointer;
 }
-#cal-day-tick {
+.cal-day-tick {
   position: absolute;
   right: 50%;
   bottom: -21px;
@@ -147,13 +147,13 @@
   width: 26px;
   margin-right: -17px;
 }
-.cal-year-box #cal-day-tick {
+.cal-year-box .cal-day-tick {
   margin-right: -7px;
 }
-#cal-slide-box {
+.cal-slide-box {
   position: relative;
 }
-#cal-slide-tick {
+.cal-slide-tick {
   position: absolute;
   width: 16px;
   margin-left: -7px;
@@ -161,37 +161,37 @@
   top: -1px;
   z-index: 1;
 }
-#cal-slide-tick.tick-month1 {
+.cal-slide-tick.tick-month1 {
   left: 12.5%;
 }
-#cal-slide-tick.tick-month2 {
+.cal-slide-tick.tick-month2 {
   left: 37.5%;
 }
-#cal-slide-tick.tick-month3 {
+.cal-slide-tick.tick-month3 {
   left: 62.5%;
 }
-#cal-slide-tick.tick-month4 {
+.cal-slide-tick.tick-month4 {
   left: 87.5%;
 }
-#cal-slide-tick.tick-day1 {
+.cal-slide-tick.tick-day1 {
   left: 7.14285714285715%;
 }
-#cal-slide-tick.tick-day2 {
+.cal-slide-tick.tick-day2 {
   left: 21.42857142857143%;
 }
-#cal-slide-tick.tick-day3 {
+.cal-slide-tick.tick-day3 {
   left: 35.71428571428572%;
 }
-#cal-slide-tick.tick-day4 {
+.cal-slide-tick.tick-day4 {
   left: 50%;
 }
-#cal-slide-tick.tick-day5 {
+.cal-slide-tick.tick-day5 {
   left: 64.2857142857143%;
 }
-#cal-slide-tick.tick-day6 {
+.cal-slide-tick.tick-day6 {
   left: 78.57142857142859%;
 }
-#cal-slide-tick.tick-day7 {
+.cal-slide-tick.tick-day7 {
   left: 92.85714285714285%;
 }
 .events-list {
@@ -200,7 +200,7 @@
   left: 0;
   overflow: hidden;
 }
-#cal-slide-content ul.unstyled {
+.cal-slide-content ul.unstyled {
   margin-bottom: 0;
 }
 .cal-week-box {
@@ -246,40 +246,41 @@
   border-left: 8px solid #FFFFFF;
   border-bottom: 15px solid transparent;
 }
-#cal-day-box {
+.cal-day-box {
   text-wrap: none;
 }
-#cal-day-box .cal-day-hour-part {
-  height: 30px;
+.cal-day-box .cal-day-hour-part {
   box-sizing: border-box;
   -moz-box-sizing: border-box;
   -webkit-box-sizing: border-box;
   border-bottom: thin dashed #e1e1e1;
 }
-#cal-day-box .cal-day-hour .day-highlight {
+.cal-day-box .cal-day-hour .day-highlight {
   height: 30px;
 }
-#cal-day-box .cal-hours {
+.cal-day-box .cal-hours {
   font-weight: bolder;
 }
-#cal-day-box .cal-day-hour:nth-child(odd) {
+.cal-day-box .cal-day-hour:nth-child(odd) {
   background-color: #fafafa;
 }
-#cal-day-box #cal-day-panel {
+.cal-day-box .cal-day-panel {
   position: relative;
   padding-left: 60px;
 }
-#cal-day-box #cal-day-panel-hour {
+.cal-day-box .cal-day-panel-hour {
   position: absolute;
   width: 100%;
   margin-left: -60px;
 }
-#cal-day-box .day-event {
+.cal-day-box .day-event {
   position: relative;
-  max-width: 200px;
   overflow: hidden;
 }
-#cal-day-box .day-highlight {
+.cal-day-box .day-event.max-width {
+  max-width: 200px;
+}
+.cal-day-box .day-highlight {
   line-height: 30px;
   padding-left: 8px;
   padding-right: 8px;
@@ -291,22 +292,22 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
-#cal-day-box .day-highlight.dh-event-important {
+.cal-day-box .day-highlight.dh-event-important {
   border: 1px solid #ad2121;
 }
-#cal-day-box .day-highlight.dh-event-warning {
+.cal-day-box .day-highlight.dh-event-warning {
   border: 1px solid #e3bc08;
 }
-#cal-day-box .day-highlight.dh-event-info {
+.cal-day-box .day-highlight.dh-event-info {
   border: 1px solid #1e90ff;
 }
-#cal-day-box .day-highlight.dh-event-inverse {
+.cal-day-box .day-highlight.dh-event-inverse {
   border: 1px solid #1b1b1b;
 }
-#cal-day-box .day-highlight.dh-event-success {
+.cal-day-box .day-highlight.dh-event-success {
   border: 1px solid #006400;
 }
-#cal-day-box .day-highlight.dh-event-special {
+.cal-day-box .day-highlight.dh-event-special {
   background-color: #ffe6ff;
   border: 1px solid #800080;
 }
@@ -464,37 +465,37 @@ span[data-cal-date]:hover {
 .cal-day-weekend span[data-cal-date] {
   color: darkred;
 }
-#cal-week-box {
+.cal-week-box {
   border: 1px solid #e1e1e1;
   border-right: 0px;
   border-radius: 5px 0 0 5px;
   background-color: #fafafa;
   text-align: right;
 }
-#cal-day-tick {
+.cal-day-tick {
   border: 1px solid #e1e1e1;
   border-top: 0px solid;
   border-radius: 0 0 5px 5px;
   background-color: #ededed;
   text-align: center;
 }
-#cal-slide-box {
+.cal-slide-box {
   border-top: 0px solid #8c8c8c;
 }
-#cal-slide-content {
+.cal-slide-content {
   padding: 20px;
   color: #ffffff;
   background-image: url("../img/dark_wood.png");
   -webkit-box-shadow: inset 0px 0px 15px 0px rgba(0, 0, 0, 0.5);
   box-shadow: inset 0px 0px 15px 0px rgba(0, 0, 0, 0.5);
 }
-#cal-slide-tick {
+.cal-slide-tick {
   background-image: url("../img/tick.png?2");
 }
-#cal-slide-content:hover {
+.cal-slide-content:hover {
   background-color: transparent;
 }
-#cal-slide-content a.event-item {
+.cal-slide-content a.event-item {
   color: #ffffff;
   font-weight: normal;
   line-height: 22px;

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -71,7 +71,7 @@ if(!String.prototype.formatNum) {
 		// define event width by css or auto width
 		event_css_max_width: true,
 		// cut events
-		cut_event: false,
+		cut_event: true,
 		// Source of events data. It can be one of the following:
 		// - URL to return JSON list of events in special format.
 		//   {success:1, result: [....]} or for error {success:0, error:'Something terrible happened'}

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -588,7 +588,7 @@ if(!String.prototype.formatNum) {
 			}
 
 			e.lines = lines_in_event;
-			if(lines_in_event > lines_left && this.options.cut_event) {
+			if(lines_in_event > lines_left && $self.options.cut_event) {
 				e.lines = lines_left;
 			}
 

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -900,6 +900,10 @@ if(!String.prototype.formatNum) {
 			source = this.options.events_url;
 			warn('The events_url option is DEPRECATED and it will be REMOVED in near future. Please use events_source instead.');
 		}
+		var headers = null;
+		if('headers' in this.options && this.options.headers !== '') {
+			headers = this.options.headers;
+		}
 		var loader;
 		switch($.type(source)) {
 			case 'function':
@@ -927,7 +931,8 @@ if(!String.prototype.formatNum) {
 							url: buildEventsUrl(source, params),
 							dataType: 'json',
 							type: 'GET',
-							async: false
+							async: false,
+							headers: headers,
 						}).done(function(json) {
 							if(!json.success) {
 								$.error(json.error);

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -62,6 +62,16 @@ if(!String.prototype.formatNum) {
 		time_start: '06:00',
 		time_end: '22:00',
 		time_split: '30',
+		// height for an hour
+		hour_height: 30,
+		// start on hour
+		always_start_on_hour: false,
+		// allow event over midnight
+		allow_over_midnight: false,
+		// define event width by css or auto width
+		event_css_max_width: true,
+		// cut events
+		cut_event: false,
 		// Source of events data. It can be one of the following:
 		// - URL to return JSON list of events in special format.
 		//   {success:1, result: [....]} or for error {success:0, error:'Something terrible happened'}
@@ -437,6 +447,9 @@ if(!String.prototype.formatNum) {
 
 		data.events = this.getEventsBetween(start, end);
 
+		// height for an hour
+		data.hour_height = this.options.hour_height;
+
 		switch(this.options.view) {
 			case 'month':
 				break;
@@ -496,13 +509,30 @@ if(!String.prototype.formatNum) {
 		var time_start = this.options.time_start.split(":");
 		var time_end = this.options.time_end.split(":");
 
-		data.hours = (parseInt(time_end[0]) - parseInt(time_start[0])) * time_split_hour;
+		var hour_end = parseInt(time_end[0])
+		// calculate end hour if minutes > 0
+		if (parseInt(time_end[1]) > 0) {
+			hour_end++;
+		}
+		// event over midnight not allowed
+		if (!this.options.allow_over_midnight) {
+			data.hours = (parseInt(time_end[0]) - parseInt(time_start[0])) * time_split_hour;
+		}
+		// over midnight allowed but time_start is before time_end
+		else if (this.options.allow_over_midnight && parseInt(time_end[0]) > parseInt(time_start[0])) {
+			data.hours = (hour_end - parseInt(time_start[0])) * time_split_hour;
+		}
+		// over midnight allowed so extend hours to display it correctly
+		else if (this.options.allow_over_midnight) {
+			data.hours = (hour_end - parseInt(time_start[0]) + 24) * time_split_hour;
+		}
+
 		var lines = data.hours * time_split_count - parseInt(time_start[1]) / time_split;
 		var ms_per_line = (60000 * time_split);
 
 		var start = new Date(this.options.position.start.getTime());
 		start.setHours(time_start[0]);
-		start.setMinutes(time_start[1]);
+		start.setMinutes(this.options.always_start_on_hour ? 0 : time_start[1]);
 		var end = new Date(this.options.position.end.getTime());
 		end.setHours(time_end[0]);
 		end.setMinutes(time_end[1]);
@@ -558,7 +588,7 @@ if(!String.prototype.formatNum) {
 			}
 
 			e.lines = lines_in_event;
-			if(lines_in_event > lines_left) {
+			if(lines_in_event > lines_left && this.options.cut_event) {
 				e.lines = lines_left;
 			}
 
@@ -579,7 +609,8 @@ if(!String.prototype.formatNum) {
 	Calendar.prototype._hour = function(hour, part) {
 		var time_start = this.options.time_start.split(":");
 		var time_split = parseInt(this.options.time_split);
-		var h = "" + (parseInt(time_start[0]) + hour * Math.max(time_split / 60, 1));
+		// modulo 24 to display correct time after midnight
+		var h = "" + (parseInt(time_start[0]) + hour * Math.max(time_split / 60, 1)) % 24;
 		var m = "" + time_split * part;
 
 		return this._format_hour(h.formatNum(2) + ":" + m.formatNum(2));
@@ -1096,7 +1127,17 @@ if(!String.prototype.formatNum) {
 	};
 
 	Calendar.prototype._update_day = function() {
-		$('#cal-day-panel').height($('#cal-day-panel-hour').height());
+		// set calendar height
+		var panelHour = $('.cal-day-panel-hour', this.context);
+		$('.cal-day-panel', this.context).height(panelHour.height());
+		// option to set event full width
+		if (this.options.event_css_max_width) {
+			// define max width by css
+			$('.day-event', this.context).addClass('max-width');
+		} else {
+			// auto width
+			$('.day-event', this.context).width(panelHour.find('.span11.col-xs-11').width() * .95);
+		}
 	};
 
 	Calendar.prototype._update_week = function() {
@@ -1220,7 +1261,7 @@ if(!String.prototype.formatNum) {
 			}));
 			row.after(slider);
 			self.activecell = $('[data-cal-date]', cell).text();
-			$('#cal-slide-tick').addClass('tick' + tick_position).show();
+			$('.cal-slide-tick').addClass('tick' + tick_position).show();
 			slider.slideDown('fast', function() {
 				$('body').one('click', function() {
 					slider.slideUp('fast');

--- a/tmpls/day.html
+++ b/tmpls/day.html
@@ -1,4 +1,4 @@
-<div id="cal-day-box">
+<div class="cal-day-box">
 	<div class="row-fluid clearfix cal-row-head">
 		<div class="span1 col-xs-1 cal-cell"><%= cal.locale.time %></div>
 		<div class="span11 col-xs-11 cal-cell"><%= cal.locale.events %></div>
@@ -24,20 +24,18 @@
 				<% _.each(before_time, function(event){ %>
 					<div class="day-highlight dh-<%= event['class'] %>">
 						<span class="cal-hours pull-right"><%= event.end_hour %></span>
-						<a href="<%= event.url ? event.url : 'javascript:void(0)' %>" data-event-id="<%= event.id %>"
-						   data-event-class="<%= event['class'] %>" class="event-item">
-							<%= event.title %></a>
+						<a href="<%= event.url ? event.url : 'javascript:void(0)' %>" data-event-id="<%= event.id %>" data-event-class="<%= event['class'] %>" class="event-item"><%= event.title %></a>
 					</div>
 				<% }); %>
 			</div>
 		</div>
 	<% }; %>
-	<div id="cal-day-panel" class="clearfix">
-		<div id="cal-day-panel-hour">
+	<div class="cal-day-panel clearfix">
+		<div class="cal-day-panel-hour">
 			<% for(i = 0; i < hours; i++){ %>
 				<div class="cal-day-hour">
 					<% for(l = 0; l < cal._hour_min(i); l++){ %>
-						<div class="row-fluid cal-day-hour-part">
+						<div class="row-fluid cal-day-hour-part" style="height:<%= hour_height %>px">
 							<div class="span1 col-xs-1"><b><%= cal._hour(i, l) %></b></div>
 							<div class="span11 col-xs-11"></div>
 						</div>
@@ -47,7 +45,7 @@
 		</div>
 		
 		<% _.each(by_hour, function(event){ %>
-			<div class="pull-left day-event day-highlight dh-<%= event['class'] %>" style="margin-top: <%= (event.top * 30) %>px; height: <%= (event.lines * 30) %>px">
+			<div class="pull-left day-event day-highlight dh-<%= event['class'] %>" style="background-color:<%= event.color ? event.color : '' %>; margin-top: <%= (event.top * hour_height) %>px; height: <%= (event.lines * hour_height) %>px">
 				<span class="cal-hours"><%= event.start_hour %> - <%= event.end_hour %></span>
 				<a href="<%= event.url ? event.url : 'javascript:void(0)' %>" data-event-id="<%= event.id %>"
 				   data-event-class="<%= event['class'] %>" class="event-item">


### PR DESCRIPTION
Add some extra options and default values : 

// define via JS options the height for an hour
		hour_height: 30,
// override start date to always start on rounded hour :  in my case start date is defined by the first event on date, so if it starts at 09:15, it's most elegant to display start at 09:00
		always_start_on_hour: false,
// allow event to go over midnight on the same day : usefull on day view to display the end after midnight
		allow_over_midnight: false,
// define if event width is defined by max-width in css or set to auto width
		event_css_max_width: true,
// define if events can be cut or not
		cut_event: true,

Also add color property to event to define manually his background-color (rgb, hexa, ...) instead of using class property.

Note : default values doesn't change actuel rendering