### PR TITLE
fix bug with end date it was always in feature and "Starts after time line" never hits

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -505,7 +505,7 @@ if(!String.prototype.formatNum) {
 		var start = new Date(this.options.position.start.getTime());
 		start.setHours(time_start[0]);
 		start.setMinutes(time_start[1]);
-		var end = new Date(this.options.position.end.getTime());
+		var end = new Date(this.options.position.end.getTime()-(86400000));
 		end.setHours(time_end[0]);
 		end.setMinutes(time_end[1]);
 


### PR DESCRIPTION
Otherwise after time never hits.
```js
if(e.start > end.getTime()) {
    data.after_time.push(e);
    return;
}
```
Bug appears during day view when event start time is bigger then calendar working hours end.