### PR TITLE
fix for #435

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -598,19 +598,24 @@ if(!String.prototype.formatNum) {
 		var first_day = getExtentedOption(this, 'first_day');
 
 		$.each(this.getEventsBetween(start, end), function(k, event) {
-			event.start_day = new Date(parseInt(event.start)).getDay();
+			var eventStart  = new Date(parseInt(event.start));
+			eventStart.setHours(0,0,0,0);
+			var eventEnd    = new Date(parseInt(event.end));
+			eventEnd.setHours(23,59,59,999);
+
+			event.start_day = new Date(parseInt(eventStart.getTime())).getDay();
 			if(first_day == 1) {
 				event.start_day = (event.start_day + 6) % 7;
 			}
-			if((event.end - event.start) <= 86400000) {
+			if((eventEnd.getTime() - eventStart.getTime()) <= 86400000) {
 				event.days = 1;
 			} else {
-				event.days = ((event.end - event.start) / 86400000);
+				event.days = ((eventEnd.getTime() - eventStart.getTime()) / 86400000);
 			}
 
-			if(event.start < start) {
+			if(eventStart.getTime() < start) {
 
-				event.days = event.days - ((start - event.start) / 86400000);
+				event.days = event.days - ((start - eventStart.getTime()) / 86400000);
 				event.start_day = 0;
 			}
 


### PR DESCRIPTION
This PR fixes issue #435.

The code is 1:1 what @gecata83 provided back in 2014.

The original code uses the time between start and end time to determine the amount of days the event lasts. This has one flaw, there could be less than 24h events and still span over two days. (partial days but still).
The fix sets the start and end date-time to its extremes (00:00:00 start, and 23:59:59 end date) for the days calculation.

So a meeting starting 15:00 and ends 08:00 the following day will be displayed on both days in weekly view.
