### PR TITLE
Allow repeating events based on class name

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -1223,6 +1223,7 @@ if(!String.prototype.formatNum) {
 
 	Calendar.prototype.getEventsBetween = function(start, end) {
 		var events = [];
+		var cal = this;
 		$.each(this.options.events, function() {
 			if(this.start == null) {
 				return true;
@@ -1230,7 +1231,6 @@ if(!String.prototype.formatNum) {
 			var event_end = this.end || this.start;
 			
 			/* Allow repeating events based on class name */
-			var cal = this;
 			if (this.class == "birthday" || this.class == "anniversary" || this.class == "annual") {
 				var repeat_start = new Date(this.start);
 				var repeat_end = new Date(this.end);

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -1228,6 +1228,19 @@ if(!String.prototype.formatNum) {
 				return true;
 			}
 			var event_end = this.end || this.start;
+			
+			/* Allow repeating events based on class name */
+			var cal = this;
+			if (this.class == "birthday" || this.class == "anniversary" || this.class == "annual") {
+				var repeat_start = new Date(this.start);
+				var repeat_end = new Date(this.end);
+				var this_year = cal.options.position.start.getFullYear();
+				repeat_start.setFullYear(this_year);
+				repeat_end.setFullYear(this_year);
+				this.start = repeat_start.getTime();
+				this.end = repeat_end.getTime();
+			}
+			
 			if((parseInt(this.start) < end) && (parseInt(event_end) >= start)) {
 				events.push(this);
 			}


### PR DESCRIPTION
Given a class name of "birthday", "anniversary" or "annual", this block of code will allow an event to show up every year on that date using the Javascript Date() object to make the calculation.
