### PR TITLE
Add second argument to the _format_hour() function to add leading zer…

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -462,10 +462,12 @@ if(!String.prototype.formatNum) {
 		this._update();
 	};
 
-	Calendar.prototype._format_hour = function(str_hour) {
+	Calendar.prototype._format_hour = function(str_hour, leadingZero) {
 		var hour_split = str_hour.split(":");
 		var hour = parseInt(hour_split[0]);
 		var minutes = parseInt(hour_split[1]);
+		var leadingZero = leadingZero == 'undefined' ? true : false;
+		var hourLength = leadingZero ? 2 : 1;
 
 		var suffix = '';
 
@@ -483,7 +485,7 @@ if(!String.prototype.formatNum) {
 			}
 		}
 
-		return hour.toString().formatNum(2) + ':' + minutes.toString().formatNum(2) + suffix;
+		return hour.toString().formatNum(hourLength) + ':' + minutes.toString().formatNum(2) + suffix;
 	};
 
 	Calendar.prototype._format_time = function(datetime) {


### PR DESCRIPTION
…o or not

The second argument to _format_hour() function leadingZero is boolean, default is true so it passes 2 to formatNum(). When set to false, it passes 1 and it returns a time format with no leading zeron.