### PR TITLE
Fix event selection for daylight saving changes

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -716,7 +716,11 @@ if(!String.prototype.formatNum) {
 		t.day = day;
 
 		t.start = parseInt(curdate.getTime());
-		t.end = parseInt(t.start + 86400000);
+		// In case of a daylight saving switch we can not assume that
+		// one calendar day is 86400000 ms so we set the date to the
+		// end of the day manally.
+		curdate.setHours(23, 59, 59, 999)
+		t.end = parseInt(curdate.getTime());
 		t.events = this.getEventsBetween(t.start, t.end);
 		return this.options.templates['month-day'](t);
 	}


### PR DESCRIPTION
On days where daylight saving is toggled the day does not last exactly
86400000 ms.  In the timezone Europe/Berlin for example daylight saving
time was toggled on 2022-03-27 at 02:00 hours.  This results in
2022-03-27T00:00:00 + 86400000 ms = 2022-03-28T01:00:00.  Therefore
events where displayed on the wrong day.